### PR TITLE
Changed search prompt to something more descriptive

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/SearchManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchManager.cs
@@ -49,7 +49,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void SearchAuthors()
         {
-            Console.Write("Tag> ");
+            Console.Write("Enter tag name> ");
             string tagName = Console.ReadLine();
 
             SearchResults<Author> results = _tagRepository.SearchAuthors(tagName);
@@ -66,7 +66,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void SearchBlogs()
         {
-            Console.Write("Tag> ");
+            Console.Write("Enter tag name> ");
             string tagName = Console.ReadLine();
 
             SearchResults<Blog> results = _tagRepository.SearchBlogs(tagName);
@@ -83,7 +83,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void SearchPosts()
         {
-            Console.Write("Tag> ");
+            Console.Write("Enter tag name> ");
             string tagName = Console.ReadLine();
 
             SearchResults<Post> results = _tagRepository.SearchPosts(tagName);
@@ -100,7 +100,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void SearchAll()
         {
-            Console.Write("Tag> ");
+            Console.Write("Enter tag name> ");
             string tagName = Console.ReadLine();
 
             SearchResults<Author> resultsAuthor = _tagRepository.SearchAuthors(tagName);


### PR DESCRIPTION
# Description
Changed search prompt from "tag>" to the more descriptive "Enter tag name>"

Please delete options that are not relevant.
- [x] Usability fix
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Testing Instructions
Go to search menu and try searching for something. Prompt should say "Enter tag name>"
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works